### PR TITLE
Hillgrove Open House Link

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,5 +18,8 @@ sections:
         - title: Notifications to Parents
           description: ""
           url: https://sites.google.com/moe.edu.sg/hgv-pg
+        - title: Hillgrove Open House
+          description: ""
+          url: https://sites.google.com/moe.edu.sg/hgv-openhouse
       url: https://sites.google.com/moe.edu.sg/hgv-sec1
 ---


### PR DESCRIPTION
Created the Hillgrove Open House Microsite link on the main page of the school website (beside Notifications to parents) so that it is prominent on the school website for members of public to access. This link on the main page will be removed on 1st December 2023.